### PR TITLE
Replacing mash with hash functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ In your view file call `getFormFields` wherever you want to output the hidden in
 To use SHA256 or SHA512 algorithms, simply pass the php MHASH constant as second parameter:
 
 ```php
-$postfinance256 = new Offline\PaymentGateways\PostFinance($shaInSignature, MHASH_SHA256);
-$postfinance512 = new Offline\PaymentGateways\PostFinance($shaInSignature, MHASH_SHA512);
+$postfinance256 = new Offline\PaymentGateways\PostFinance($shaInSignature, 'sha256');
+$postfinance512 = new Offline\PaymentGateways\PostFinance($shaInSignature, 'sha512');
 ```
 
 ### Validating SHA-OUT signatures   

--- a/src/Offline/PaymentGateways/PostFinance.php
+++ b/src/Offline/PaymentGateways/PostFinance.php
@@ -27,9 +27,9 @@ class PostFinance
      *
      * @throws InvalidArgumentException
      */
-    public function __construct($shaSig, $algorithm = MHASH_SHA1)
+    public function __construct($shaSig, $algorithm = 'sha1')
     {
-        if ( ! in_array($algorithm, [MHASH_SHA1, MHASH_SHA256, MHASH_SHA512])) {
+        if ( ! in_array($algorithm, ['sha1', 'sha256', 'sha512'])) {
             throw new InvalidArgumentException('Invalid Algorithm specified!');
         }
 
@@ -129,7 +129,7 @@ class PostFinance
      */
     protected function generateDigest($hashString)
     {
-        return strtoupper(bin2hex(mhash($this->algorithm, $hashString)));
+        return hash($this->algorithm, $hashString);
     }
 
     /**


### PR DESCRIPTION
mahsh() ist obsolete since PHP 5.3 and does not work on servers without
additional MHASH support enabled (testet on PHP 7.1)